### PR TITLE
[indigo] Add ignored package that is recently added.

### DIFF
--- a/indigo.ignored
+++ b/indigo.ignored
@@ -1,1 +1,2 @@
+pr2_jacobian_tests
 pr2_moveit_tests


### PR DESCRIPTION
This relatively recently catkinized pr2_jacobian_tests package (in ros-planning/moveit_pr2#78) doesn't need to be released IMO but bloom insists on releasing. This PR addresses it and should let me move forward on making a release for the packages in the devel repo.